### PR TITLE
Added OWB 2.0 to the implementations list

### DIFF
--- a/download.html.slim
+++ b/download.html.slim
@@ -51,9 +51,9 @@ table.table.table-bordered
           ' Weld 3.0.0.Final
           i.fa.fa-download
       td
-        /%a{:href=>'http://openwebbeans.apache.org/download.html', :target=>'_BLANK'}
-          Apache OWB 1.6
-          %i.fa.fa-download
+        a href='http://openwebbeans.apache.org/download.html' target='_BLANK'
+          ' Apache OWB 2.0
+          i.fa.fa-download
       td
         a href='http://download.jboss.org/cdi/tck/2.0.0.Final/cdi-tck-2.0.0.Final-dist.zip'
           ' TCK 2.0.0.Final


### PR DESCRIPTION
OpenWebBeans 2.0 is missing from the list of CDI 2.0 implementations